### PR TITLE
Remove deadlines from "postJobDescription"

### DIFF
--- a/contracts/JobFactory.sol
+++ b/contracts/JobFactory.sol
@@ -132,10 +132,12 @@ contract JobFactory {
         uint64 _clientVersion
     ) public {
         uint jobId = jobs[msg.sender].length;
+        uint biddingDeadline = block.timestamp + 120;
+        uint revealDeadline = block.timestamp + 240;
         vickreyAuction.start(
             _minimumPayout,
-            _biddingDeadline,
-            _revealDeadline,
+            biddingDeadline,
+            revealDeadline,
             _workerReward,
             msg.sender);
         jobs[msg.sender].push(Job(
@@ -151,8 +153,8 @@ contract JobFactory {
             address(vickreyAuction),
             jobId,
             _workerReward,
-            _biddingDeadline,
-            _revealDeadline,
+            biddingDeadline,
+            revealDeadline,
             _clientVersion
         );
     }


### PR DESCRIPTION
Closes #24 

This PR removes the `_biddingDeadline` and `_revealDeadline` params from the `postJobDescription` function in `JobFactory` and calculates them within the function. Reason is that passing in deadlines from the daemon introduces the possibility that the bidding windows are shortened because of transaction mine time.