### PR TITLE
Fix placeBid

### DIFF
--- a/contracts/VickreyAuction.sol
+++ b/contracts/VickreyAuction.sol
@@ -300,7 +300,7 @@ contract VickreyAuction {
         if (_amount <= auctions[_endUser][_auctionId].highestBid) {
             return false;
         }
-        if (auctions[_endUser][_auctionId].highestBidder != address(0)) {
+        if (auctions[_endUser][_auctionId].highestBidder != _endUser) {
             address hb = auctions[_endUser][_auctionId].highestBidder;
             staleBids[hb] += auctions[_endUser][_auctionId].highestBid;
         }


### PR DESCRIPTION
Closes #13 

Zero-address check changed to check against `_endUser`, a zero-address wouldn't be able to make a bid anyway so that check was ineffectual. We should have been checking that an end user can't bid on their own auction, so a change was warranted.