### PR TITLE
Worker doesn't need to validate the accuracy

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["idrabenia.solidity-solhint"]
+}

--- a/contracts/JobFactory.sol
+++ b/contracts/JobFactory.sol
@@ -41,7 +41,6 @@ contract JobFactory {
    */
     event TrainedModelShared(
         address indexed jobPoster,
-        uint64 trainingErrorRate,
         address indexed workerNode,
         uint indexed id,
         string trainedModelMagnetLink
@@ -198,23 +197,19 @@ contract JobFactory {
    * @param _jobPoster address data scientist's address
    * @param _id uint job ID
    * @param _trainedModelMagnetLink string trained model link
-   * @param _trainingErrorRate uint64 training error rate
    */
     function shareTrainedModel(
         address _jobPoster,
         uint _id,
-        string memory _trainedModelMagnetLink,
-        uint64 _trainingErrorRate
+        string memory _trainedModelMagnetLink
     ) public {
         Job memory job = jobs[_jobPoster][_id];
         require(job.workerNode != address(0), 'Worker Node has not yet been selected');
         require(msg.sender == job.workerNode,'msg.sender must equal workerNode');
         require(job.status == Status.SharedUntrainedModelAndTrainingDataset,'Untrained model and training dataset has not been shared');
-        require(job.targetErrorRate >= _trainingErrorRate,'targetErrorRate must be greater or equal to _trainingErrorRate');
         jobs[_jobPoster][_id].status = Status.SharedTrainedModel;
         emit TrainedModelShared(
             _jobPoster,
-            _trainingErrorRate,
             msg.sender,
             _id,
             _trainedModelMagnetLink

--- a/test/IntegrationTests/E2EAuctionJob.js
+++ b/test/IntegrationTests/E2EAuctionJob.js
@@ -425,12 +425,7 @@ describe("Complete E2E Workflow", async () => {
     await expect(
       jobFactory
         .connect(worker2)
-        .shareTrainedModel(
-          poster.address,
-          auctionID,
-          trainedModelMagnetLink,
-          targetErrorRate
-        )
+        .shareTrainedModel(poster.address, auctionID, trainedModelMagnetLink)
     ).to.be.revertedWith("Worker Node has not yet been selected");
   });
 
@@ -464,12 +459,7 @@ describe("Complete E2E Workflow", async () => {
     await expect(
       jobFactory
         .connect(badActorWorker)
-        .shareTrainedModel(
-          poster.address,
-          auctionID,
-          trainedModelMagnetLink,
-          targetErrorRate
-        )
+        .shareTrainedModel(poster.address, auctionID, trainedModelMagnetLink)
     ).to.be.revertedWith("msg.sender must equal workerNode");
   });
 
@@ -489,12 +479,7 @@ describe("Complete E2E Workflow", async () => {
   it("A worker can share the trained model", async () => {
     const tx = await jobFactory
       .connect(worker2)
-      .shareTrainedModel(
-        poster.address,
-        auctionID,
-        trainedModelMagnetLink,
-        targetErrorRate
-      );
+      .shareTrainedModel(poster.address, auctionID, trainedModelMagnetLink);
 
     let { events } = await tx.wait();
     let event = events.pop();
@@ -502,10 +487,9 @@ describe("Complete E2E Workflow", async () => {
 
     expect(event.event).to.equal("TrainedModelShared");
     expect(shareTrainedModel[0]).to.equal(poster.address);
-    expect(shareTrainedModel[1]).to.equal(targetErrorRate);
-    expect(shareTrainedModel[2]).to.equal(worker2.address);
-    expect(shareTrainedModel[3]).to.equal(auctionID);
-    expect(shareTrainedModel[4]).to.equal(trainedModelMagnetLink);
+    expect(shareTrainedModel[1]).to.equal(worker2.address);
+    expect(shareTrainedModel[2]).to.equal(auctionID);
+    expect(shareTrainedModel[3]).to.equal(trainedModelMagnetLink);
   });
 
   it("Cannot approva a job before testing dataset has been shared", async () => {


### PR DESCRIPTION
The worker should not be responsible and be reverted for a model that does not converge to the accuracy specified by the data scientist.